### PR TITLE
Add dockerfile for using inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Use last Composer image running PHP 7
+FROM composer@sha256:d374b2e1f715621e9d9929575d6b35b11cf4a6dc237d4a08f2e6d1611f534675
+
+RUN docker-php-ext-install mysqli pdo pdo_mysql && docker-php-ext-enable mysqli pdo pdo_mysql
+
+RUN composer require --dev dholmes/bga-workbench
+
+ENTRYPOINT ["/app/vendor/bin/bgawb"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Via composer:
 composer require --dev dholmes/bga-workbench
 ```
 
+Via Docker:
+```bash
+docker build -t bgawb .
+alias bgawb="docker run --rm -v $PWD:/data -w /data bgawb"
+```
+(this last line should be set in your ~/.bashrc to keep the alias working in a new terminal)
+
+
 To set up your project to work with BGA Workbench you need to have a `bgaproject.yml` file in the root. To generate one 
 see the [`bgawb init` command](#initialise-bga-project).
 


### PR DESCRIPTION
Being used to Docker, I preferred to create a Docker image for bga-workbench instead of installing it directly with composer. Also Docker is lighter than Vagrant.

I share this Dockerfile if anyone is interested. Feel free to host the Docker image on the Docker Hub if you wish.

I added the instructions how to use it in the Readme