### PR TITLE
Remove 7.0, 7.1 PHP versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         php_version:
-          - "7.0"
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"


### PR DESCRIPTION
[BGA supports 7.2](https://en.doc.boardgamearena.com/Studio_file_reference#software_versions) so removing the 7.0 and 7.1 versions from the build script to get the latest code changes to pass build. The build is failing due to the "void" return type, which was [added in 7.1](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.void).